### PR TITLE
release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### Version 1.1.0
+
+News
+- Add an item when the connection status change
+- Display json responses as a json tree in detail page
+- Netwatch can be displayed via:
+    - The shake event (per default)
+    - `visible` props, to display/hide via an external button .eg
+
+New props:
+- `visible`: to display/hide Netwatch without the shake event
+- `onPressClose`: action which will be called when the user will press the exit button
+
 ### Version 1.0.3
 
 Improvements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/lib_asset.png" width="60%">
 </p>
 
-[![Build Status](https://travis-ci.org/imranMnts/react-native-netwatch.svg?branch=develop)](https://travis-ci.org/imranMnts/react-native-netwatch)
+[![Build Status](https://travis-ci.org/odemolliens/react-native-netwatch.svg?branch=develop)](https://travis-ci.org/odemolliens/react-native-netwatch)
 ![npm](https://img.shields.io/npm/v/react-native-netwatch.svg)
 ![GitHub](https://img.shields.io/github/license/odemolliens/react-native-netwatch.svg)
 
@@ -14,12 +14,12 @@ Includes an interface to see http traffic from RN and native side
 ## Features
 
 - Log network requests coming from React Native side
-- Log connectivity change
 - Log network requests coming from the native side (iOS and Android) (optional)
 - Log Redux actions (optional)
 - Shake the device to display the tool
 - View details of each request/action
 - Generate and share the list of requests/actions in Excel (XLSX) file
+- Log connectivity change
 
 ## Example app
 
@@ -39,6 +39,8 @@ To avoid to have too much dependencies and conflict versions, before install, yo
 - react-native-fs
 - react-native-share
 - @react-native-community/netinfo
+
+#### Fonts
 
 Netwatch has react-native-vector-icons as dependency. Be sure that you have these fonts installed in your project:
 

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -114,3 +114,23 @@ jest.mock('react-native-device-info', () => {
     getBuildNumber: jest.fn(),
   };
 });
+
+jest.mock('@react-native-community/netinfo', () => ({
+  isConnected: {
+    addEventListener: jest.fn(),
+  },
+  getConnectionInfo: jest.fn().mockReturnValue({ type: 'test' }),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  NetInfoStateType: {
+    unknown: 'unknown',
+    none: 'none',
+    cellular: 'cellular',
+    wifi: 'wifi',
+    bluetooth: 'bluetooth',
+    ethernet: 'ethernet',
+    wimax: 'wimax',
+    vpn: 'vpn',
+    other: 'other',
+  },
+}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netwatch",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Network traffic logger for React Native",
   "homepage": "https://github.com/odemolliens/react-native-netwatch",
   "main": "lib/index.js",


### PR DESCRIPTION
News
- Add an item when the connection status change
- Display json responses as a json tree in detail page
- Netwatch can be displayed via:
    - The shake event (per default)
    - `visible` props, to display/hide via an external button .eg

New props:
- `visible`: to display/hide Netwatch without the shake event
- `onPressClose`: action which will be called when the user will press the exit button