### PR TITLE
#80 - Example project crash on metro

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,12 +1,24 @@
 # Example
 
+This example application allows one to work on test the library.
+
 ## Getting Started
 
+To run the project for the first time, please follow this process:
+
+- Ensure that the dependencies for the project are installed, from the `root` of the repository run:
+
 ```bash
-yarn
+yarn install
 ```
 
-for iOS:
+- Install the dependencies from the `example` project:
+
+```bash
+yarn install
+```
+
+- For iOS build, install the pods dependencies:
 
 ```bash
 npx pod-install


### PR DESCRIPTION
this PR closes ticket #80 

- Update the documentation to indicate the missing step needed to make the example app running
- replacing the `yarn` command with `yarn install` for clarity.