### PR TITLE
upgrading react-native-clipboard minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "testu": "TZ=UTC node_modules/.bin/jest --updateSnapshot"
   },
   "dependencies": {
-    "@react-native-clipboard/clipboard": "^1.8.4",
+    "@react-native-clipboard/clipboard": "^1.9.0",
     "react-native-json-tree": "^1.3.0",
     "url": "^0.11.0",
     "xlsx": "^0.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,10 +1271,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@react-native-clipboard/clipboard@^1.8.4":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.8.4.tgz#4bc1fb00643688e489d8220cd635844ab5c066f9"
-  integrity sha512-poFq3RvXzkbXcqoQNssbZ+aNbCRzBFAWkR9QL7u9xNMgsyWZtk7d16JQoaBo8D2E+kKi+/9JOiVQzA5w+9N67w==
+"@react-native-clipboard/clipboard@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.9.0.tgz#68d6a18545b1f986098d5fb1cd710b53c322e066"
+  integrity sha512-O/ohFq1CAQLfoNc376Z3W6gvVcCJlje5AVk0JhsI8Q40hn+NXAWCnOM1bEePfC0uDMtp0/RCK6FotUvkQ6c4Zw==
 
 "@react-native-community/cli-debugger-ui@^5.0.1":
   version "5.0.1"


### PR DESCRIPTION
This PR goal is to upgrade react-native-clipboard dependency to fix a `new NativeEventEmitter() was called with a non-null argument` crash with this library on react-native 0.65.1 preventing the use of this library.