### PR TITLE
reverting the default status of initialized from true to false

### DIFF
--- a/src/Core/RNLogger.tsx
+++ b/src/Core/RNLogger.tsx
@@ -29,7 +29,7 @@ interface IXHR {
 export class RNLogger {
   static instance: RNLogger;
 
-  initialized: boolean = true;
+  initialized: boolean = false;
   maxRequests: number = 100;
   requestId: number = 0;
   requests: Array<RNRequest> = [];


### PR DESCRIPTION
This PR changes the default value of `initialized` from true to false preventing the execution of `XHRInterceptor.enableInterception` thus preventing the monitoring of the network in some cases.

Would potentially fix:

- https://github.com/odemolliens/react-native-netwatch/issues/89
- https://github.com/odemolliens/react-native-netwatch/issues/54
