### PR TITLE
Fix Android crash when mocking response while using fetch 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netwatch",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Network traffic logger for React Native",
   "homepage": "https://github.com/odemolliens/react-native-netwatch",
   "main": "src/index.tsx",

--- a/src/Core/Objects/RNRequest.tsx
+++ b/src/Core/Objects/RNRequest.tsx
@@ -24,7 +24,7 @@ export const getRequestBody = (dataSent: any): string => stringifyData(dataSent)
 
 export const getResponseBody = async (responseType: string, response?: any): Promise<string> => {
   if (!response) return '';
-  const _responseBody = await (responseType !== 'blob' ? response : parseResponseBlob(response));
+  const _responseBody = await ((responseType === 'blob' && typeof response !== 'string') ?  parseResponseBlob(response): response);
   return stringifyData(_responseBody || '');
 };
 


### PR DESCRIPTION
By default, the whatwg-fetch library sets the responseType to 'blob' if the device supports blob types. However, when mocking responses, the xhr.response field is populated as a string.

Netwatch typically uses the responseType to determine if it should parse the response. When set to 'blob', it mistakenly invokes the native BlobFileReader to parse this string, leading to an error."